### PR TITLE
Add docker parameters for models

### DIFF
--- a/oton/config.toml
+++ b/oton/config.toml
@@ -8,5 +8,5 @@ docker_models_dir = "/usr/local/share/ocrd-resources"
 
 # See https://www.nextflow.io/docs/latest/process.html#script for the difference
 # between NextFlow and Bash variables.
-venv_path = "\\$HOME/git/ocrd_all/venv/bin/activate"
-models_path = "$projectDir/models"
+venv_path = "\\$HOME/venv37-ocrd/bin/activate"
+models_path = "\\$HOME/ocrd_models"

--- a/oton/config.toml
+++ b/oton/config.toml
@@ -4,7 +4,9 @@ mets_path = "$projectDir/ocrd-workspace/mets.xml"
 # Dockerized parameters
 docker_pwd = "/ocrd-workspace"
 docker_image = "ocrd/all:maximum"
+docker_models_dir = "/usr/local/share/ocrd-resources"
 
 # See https://www.nextflow.io/docs/latest/process.html#script for the difference
 # between NextFlow and Bash variables.
-venv_path = "\\$HOME/venv37-ocrd/bin/activate"
+venv_path = "\\$HOME/git/ocrd_all/venv/bin/activate"
+models_path = "$projectDir/models"

--- a/oton/constants.py
+++ b/oton/constants.py
@@ -14,6 +14,7 @@ __all__ = [
 
     "PARAMS_KEY_DOCKER_PWD",
     "PARAMS_KEY_DOCKER_VOLUME",
+    "PARAMS_KEY_DOCKER_MODELS",
     "PARAMS_KEY_DOCKER_IMAGE",
     "PARAMS_KEY_DOCKER_COMMAND",
     "PARAMS_KEY_METS_PATH",
@@ -22,6 +23,7 @@ __all__ = [
 
     "PARAMS_VAL_DOCKER_PWD",
     "PARAMS_VAL_DOCKER_VOLUME",
+    "PARAMS_VAL_DOCKER_MODELS",
     "PARAMS_VAL_DOCKER_IMAGE",
     "PARAMS_VAL_DOCKER_COMMAND",
     "PARAMS_VAL_METS_PATH",
@@ -31,15 +33,18 @@ __all__ = [
     "REPR_DSL2",
     "REPR_DOCKER_COMMAND",
     "REPR_DOCKER_IMAGE",
+    "REPR_DOCKER_MODELS",
+    "REPR_DOCKER_MODELS_DIR",
     "REPR_DOCKER_PWD",
     "REPR_DOCKER_VOLUME",
     "REPR_METS_PATH",
+    "REPR_MODELS_PATH",
     "REPR_VENV_PATH",
     "REPR_WORKSPACE_PATH",
 
     "PH_DOCKER_COMMAND",
-    "PH_IN_DIR",
-    "PH_OUT_DIR",
+    "PH_DIR_IN",
+    "PH_DIR_OUT",
     "PH_VENV_PATH"
 ]
 
@@ -60,7 +65,10 @@ PARAMS_KEY_DOCKER_COMMAND: str = 'params.docker_command'
 PARAMS_KEY_DOCKER_IMAGE: str = 'params.docker_image'
 PARAMS_KEY_DOCKER_PWD: str = 'params.docker_pwd'
 PARAMS_KEY_DOCKER_VOLUME: str = 'params.docker_volume'
+PARAMS_KEY_DOCKER_MODELS: str = 'params.docker_models'
+PARAMS_KEY_DOCKER_MODELS_DIR: str = 'params.docker_models_dir'
 PARAMS_KEY_METS_PATH: str = 'params.mets_path'
+PARAMS_KEY_MODELS_PATH: str = 'params.models_path'
 PARAMS_KEY_VENV_PATH: str = 'params.venv_path'
 PARAMS_KEY_WORKSPACE_PATH: str = 'params.workspace_path'
 
@@ -68,6 +76,7 @@ def __build_docker_command():
     docker_command = 'docker run --rm'
     docker_command += f' -u \\$(id -u)'
     docker_command += f' -v ${PARAMS_KEY_DOCKER_VOLUME}'
+    docker_command += f' -v ${PARAMS_KEY_DOCKER_MODELS}'
     docker_command += f' -w ${PARAMS_KEY_DOCKER_PWD}'
     docker_command += f' -- ${PARAMS_KEY_DOCKER_IMAGE}'
     return docker_command
@@ -83,7 +92,10 @@ PARAMS_VAL_VENV_PATH: str = TOML_CONFIG["venv_path"]
 PARAMS_VAL_WORKSPACE_PATH: str = TOML_CONFIG["workspace_path"]
 PARAMS_VAL_DOCKER_IMAGE: str = TOML_CONFIG["docker_image"]
 PARAMS_VAL_DOCKER_PWD: str = TOML_CONFIG["docker_pwd"]
+PARAMS_VAL_MODELS_PATH: str = TOML_CONFIG["models_path"]
+PARAMS_VAL_DOCKER_MODELS_DIR: str = TOML_CONFIG["docker_models_dir"]
 PARAMS_VAL_DOCKER_VOLUME: str = f'${PARAMS_KEY_WORKSPACE_PATH}:${PARAMS_KEY_DOCKER_PWD}'
+PARAMS_VAL_DOCKER_MODELS: str = f'${PARAMS_KEY_MODELS_PATH}:${PARAMS_KEY_DOCKER_MODELS_DIR}'
 PARAMS_VAL_DOCKER_COMMAND: str = __build_docker_command()
 
 def __build_repr(parameter, value):
@@ -93,9 +105,12 @@ def __build_repr(parameter, value):
 REPR_DSL2: str = 'nextflow.enable.dsl = 2'
 REPR_DOCKER_COMMAND: str = __build_repr(PARAMS_KEY_DOCKER_COMMAND, PARAMS_VAL_DOCKER_COMMAND)
 REPR_DOCKER_IMAGE: str = __build_repr(PARAMS_KEY_DOCKER_IMAGE, PARAMS_VAL_DOCKER_IMAGE)
+REPR_DOCKER_MODELS: str = __build_repr(PARAMS_KEY_DOCKER_MODELS, PARAMS_VAL_DOCKER_MODELS)
+REPR_DOCKER_MODELS_DIR: str = __build_repr(PARAMS_KEY_DOCKER_MODELS_DIR, PARAMS_VAL_DOCKER_MODELS_DIR)
 REPR_DOCKER_PWD: str = __build_repr(PARAMS_KEY_DOCKER_PWD, PARAMS_VAL_DOCKER_PWD)
 REPR_DOCKER_VOLUME: str = __build_repr(PARAMS_KEY_DOCKER_VOLUME, PARAMS_VAL_DOCKER_VOLUME)
 REPR_METS_PATH: str = __build_repr(PARAMS_KEY_METS_PATH, PARAMS_VAL_METS_PATH)
+REPR_MODELS_PATH: str = __build_repr(PARAMS_KEY_MODELS_PATH, PARAMS_VAL_MODELS_PATH)
 REPR_VENV_PATH: str = __build_repr(PARAMS_KEY_VENV_PATH, PARAMS_VAL_VENV_PATH)
 REPR_WORKSPACE_PATH: str = __build_repr(PARAMS_KEY_WORKSPACE_PATH, PARAMS_VAL_WORKSPACE_PATH)
 

--- a/oton/nextflow_script.py
+++ b/oton/nextflow_script.py
@@ -8,9 +8,12 @@ from .constants import (
     REPR_DSL2,
     REPR_DOCKER_COMMAND,
     REPR_DOCKER_IMAGE,
+    REPR_DOCKER_MODELS,
+    REPR_DOCKER_MODELS_DIR,
     REPR_DOCKER_PWD,
     REPR_DOCKER_VOLUME,
     REPR_METS_PATH,
+    REPR_MODELS_PATH,
     REPR_VENV_PATH,
     REPR_WORKSPACE_PATH
 )
@@ -29,6 +32,9 @@ class Nextflow_Script:
         if dockerized:
             self.nf_lines.append(REPR_DOCKER_PWD)
             self.nf_lines.append(REPR_DOCKER_VOLUME)
+            self.nf_lines.append(REPR_DOCKER_MODELS_DIR)
+            self.nf_lines.append(REPR_MODELS_PATH)
+            self.nf_lines.append(REPR_DOCKER_MODELS)
             self.nf_lines.append(REPR_DOCKER_IMAGE)
             self.nf_lines.append(REPR_DOCKER_COMMAND)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click
 tomli
-
+nextflow

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,4 +1,3 @@
-from distutils.command.clean import clean
 from oton.converter import Converter
 from re import sub
 import os
@@ -56,6 +55,26 @@ def test_conversion_with_docker():
     converter.convert_OtoN(input_path=input_path, output_path=output_path, dockerized=dockerized)
 
     expected = """${params.docker_command} ocrd-cis-ocropy-binarize -I ${input_dir} -O ${output_dir}"""
+
+    with open(output_path, mode='r', encoding='utf-8') as fp:
+        wf = fp.read()
+
+    clean_up(output_path)
+
+    assert expected in wf
+
+def test_models_volume_for_docker():
+    """E2E test for a Docker-base OCR-D workflow conversion with a models directory.
+    We test if the resulting NextFlow script has a volume for mounting the text detection models."""
+    
+    input_path = 'tests/assets/workflow.txt'
+    output_path = 'tests/assets/output_docker_workflow.nf'
+    dockerized = True
+
+    converter = Converter()
+    converter.convert_OtoN(input_path=input_path, output_path=output_path, dockerized=dockerized)
+
+    expected = "docker run --rm -u \\$(id -u) -v $params.docker_volume -v $params.docker_models -w $params.docker_pwd -- $params.docker_image"
 
     with open(output_path, mode='r', encoding='utf-8') as fp:
         wf = fp.read()


### PR DESCRIPTION
This PR introduces parameters for the location of OCR models to the `config.toml` in case a Dockerized workflow is created. These are used to mount a volume for the models to a container as described in https://ocr-d.de/en/models#models-and-docker.

Furthermore it fixes to minor issues:

1. Some variable names haven't been changed according to the recent refactoring. These overlooked cases have been corrected.
2. Installing `oton` in a `venv` causes errors since the `requirements.txt` lacked an entry for `nextflow`. This has been inserted.