### PR TITLE
feat: allow for duplicate processor usage in workflow

### DIFF
--- a/oton/nextflow_process.py
+++ b/oton/nextflow_process.py
@@ -8,9 +8,9 @@ from .constants import (
 )
 
 class Nextflow_Process:
-    def __init__(self, ocrd_command, dockerized=False):
+    def __init__(self, ocrd_command, index_pos, dockerized=False):
         self.dockerized = dockerized
-        self.process_name = self._extract_process_name(ocrd_command[0])
+        self.process_name = self._extract_process_name(ocrd_command[0]) + "_" + str(index_pos)
         in_index, out_index = self._find_io_files_value_indices(ocrd_command)
         ocrd_cmd_input, ocrd_cmd_output = self._find_io_files_values(ocrd_command, in_index, out_index)
         self.repr_in_workflow = [self.process_name, ocrd_cmd_input, ocrd_cmd_output]

--- a/oton/nextflow_script.py
+++ b/oton/nextflow_script.py
@@ -45,9 +45,9 @@ class Nextflow_Script:
     def build_nextflow_processes(self, ocrd_commands, dockerized=False):
         nf_processes = []
 
+        index = 0
         for ocrd_command in ocrd_commands:
-            index_pos = ocrd_commands.index(ocrd_command)
-            nextflow_process = Nextflow_Process(ocrd_command, index_pos, dockerized)
+            nextflow_process = Nextflow_Process(ocrd_command, index, dockerized)
             nextflow_process.add_directive('maxForks 1')
             nextflow_process.add_input_param(f'path {METS_FILE}')
             nextflow_process.add_input_param(f'val {DIR_IN}')
@@ -57,6 +57,7 @@ class Nextflow_Script:
 
             # This list is used when building the workflow
             nf_processes.append(nextflow_process.repr_in_workflow)
+            index += 1
 
         return nf_processes
 

--- a/oton/nextflow_script.py
+++ b/oton/nextflow_script.py
@@ -46,7 +46,8 @@ class Nextflow_Script:
         nf_processes = []
 
         for ocrd_command in ocrd_commands:
-            nextflow_process = Nextflow_Process(ocrd_command, dockerized)
+            index_pos = ocrd_commands.index(ocrd_command)
+            nextflow_process = Nextflow_Process(ocrd_command, index_pos, dockerized)
             nextflow_process.add_directive('maxForks 1')
             nextflow_process.add_input_param(f'path {METS_FILE}')
             nextflow_process.add_input_param(f'val {DIR_IN}')

--- a/tests/assets/workflow_with_duplicate_processors.txt
+++ b/tests/assets/workflow_with_duplicate_processors.txt
@@ -1,0 +1,14 @@
+   ocrd process \
+   "olena-binarize -I OCR-D-IMG -O OCR-D-BIN -P impl sauvola" \
+   "anybaseocr-crop -I OCR-D-BIN -O OCR-D-CROP" \
+   "olena-binarize -I OCR-D-CROP -O OCR-D-BIN2 -P impl kim" \
+   "cis-ocropy-denoise -I OCR-D-BIN2 -O OCR-D-BIN-DENOISE -P level-of-operation page" \
+   "cis-ocropy-deskew -I OCR-D-BIN-DENOISE -O OCR-D-BIN-DENOISE-DESKEW -P level-of-operation page" \
+   "tesserocr-segment-region -I OCR-D-BIN-DENOISE-DESKEW -O OCR-D-SEG-REG" \
+   "segment-repair -I OCR-D-SEG-REG -O OCR-D-SEG-REPAIR -P plausibilize true" \
+   "cis-ocropy-deskew -I OCR-D-SEG-REPAIR -O OCR-D-SEG-REG-DESKEW -P level-of-operation region" \
+   "cis-ocropy-clip -I OCR-D-SEG-REG-DESKEW -O OCR-D-SEG-REG-DESKEW-CLIP -P level-of-operation region" \
+   "tesserocr-segment-line -I OCR-D-SEG-REG-DESKEW-CLIP -O OCR-D-SEG-LINE" \
+   "segment-repair -I OCR-D-SEG-LINE -O OCR-D-SEG-REPAIR-LINE -P sanitize true" \
+   "cis-ocropy-dewarp -I OCR-D-SEG-REPAIR-LINE -O OCR-D-SEG-LINE-RESEG-DEWARP" \
+   "calamari-recognize -I OCR-D-SEG-LINE-RESEG-DEWARP -O OCR-D-OCR -P  checkpoint_dir qurator-gt4histocr-1.0"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -21,14 +21,14 @@ def test_conversion_wo_docker():
 
     expected_workflow = """workflow {
             main:
-                ocrd_cis_ocropy_binarize(params.mets_path, "OCR-D-IMG", "OCR-D-BIN")
-                ocrd_anybaseocr_crop(params.mets_path, ocrd_cis_ocropy_binarize.out, "OCR-D-CROP")
-                ocrd_skimage_binarize(params.mets_path, ocrd_anybaseocr_crop.out, "OCR-D-BIN2")
-                ocrd_skimage_denoise(params.mets_path, ocrd_skimage_binarize.out, "OCR-D-BIN-DENOISE")
-                ocrd_tesserocr_deskew(params.mets_path, ocrd_skimage_denoise.out, "OCR-D-BIN-DENOISE-DESKEW")
-                ocrd_cis_ocropy_segment(params.mets_path, ocrd_tesserocr_deskew.out, "OCR-D-SEG")
-                ocrd_cis_ocropy_dewarp(params.mets_path, ocrd_cis_ocropy_segment.out, "OCR-D-SEG-LINE-RESEG-DEWARP")
-                ocrd_calamari_recognize(params.mets_path, ocrd_cis_ocropy_dewarp.out, "OCR-D-OCR")
+                ocrd_cis_ocropy_binarize_0(params.mets_path, "OCR-D-IMG", "OCR-D-BIN")
+                ocrd_anybaseocr_crop_1(params.mets_path, ocrd_cis_ocropy_binarize_0.out, "OCR-D-CROP")
+                ocrd_skimage_binarize_2(params.mets_path, ocrd_anybaseocr_crop_1.out, "OCR-D-BIN2")
+                ocrd_skimage_denoise_3(params.mets_path, ocrd_skimage_binarize_2.out, "OCR-D-BIN-DENOISE")
+                ocrd_tesserocr_deskew_4(params.mets_path, ocrd_skimage_denoise_3.out, "OCR-D-BIN-DENOISE-DESKEW")
+                ocrd_cis_ocropy_segment_5(params.mets_path, ocrd_tesserocr_deskew_4.out, "OCR-D-SEG")
+                ocrd_cis_ocropy_dewarp_6(params.mets_path, ocrd_cis_ocropy_segment_5.out, "OCR-D-SEG-LINE-RESEG-DEWARP")
+                ocrd_calamari_recognize_7(params.mets_path, ocrd_cis_ocropy_dewarp_6.out, "OCR-D-OCR")
         }"""
     expected_normalized = sub(r'\s+','',expected_workflow)
 

--- a/tests/test_nextflow_process.py
+++ b/tests/test_nextflow_process.py
@@ -1,0 +1,36 @@
+from oton.nextflow_process import Nextflow_Process
+from oton.ocrd_validator import OCRD_Validator
+
+def test_line_append():
+    """Tests if each NextFlow function appends a number to the processor name
+    distinguish processor calls
+    """
+    input_path = 'tests/assets/workflow_with_duplicate_processors.txt'
+    ocrd_validator = OCRD_Validator()
+    ocrd_lines = ocrd_validator.extract_and_validate_ocrd_file(input_path)
+    ocrd_commands = ocrd_validator.extract_ocrd_commands(ocrd_lines)
+
+    result = []
+
+    for ocrd_command in ocrd_commands:
+        index_pos = ocrd_commands.index(ocrd_command)
+        nextflow_process = Nextflow_Process(ocrd_command, index_pos, dockerized=False)
+        result.append(nextflow_process.process_name)
+
+    expected = [
+        "ocrd_olena_binarize_0",
+        "ocrd_anybaseocr_crop_1",
+        "ocrd_olena_binarize_2",
+        "ocrd_cis_ocropy_denoise_3",
+        "ocrd_cis_ocropy_deskew_4",
+        "ocrd_tesserocr_segment_region_5",
+        "ocrd_segment_repair_6",
+        "ocrd_cis_ocropy_deskew_7",
+        "ocrd_cis_ocropy_clip_8",
+        "ocrd_tesserocr_segment_line_9",
+        "ocrd_segment_repair_10",
+        "ocrd_cis_ocropy_dewarp_11",
+        "ocrd_calamari_recognize_12"
+    ]
+
+    assert result == expected


### PR DESCRIPTION
This PR adds an enumeration to the NextFlow functions created during the conversion which circumvents a name clash if one or more processors are used more than once in a workflow.

Closes #6 .